### PR TITLE
IE8 and lower error fix

### DIFF
--- a/src/jquery-jec.js
+++ b/src/jquery-jec.js
@@ -411,7 +411,7 @@ value*/
                                     uneditableOptions.eq(opt.position).before(option);
                                 }
                             } else {
-                                elem.append(option);
+                                elem.append(option.html());
                             }
                         },
 
@@ -501,7 +501,7 @@ value*/
                         if (!elem.find('option.' + pluginClass).length) {
                             var editableOption = $('<option>');
                             editableOption.addClass(pluginClass);
-                            elem.append(editableOption);
+                            elem.append(editableOption.html());
                         }
 
                         elem.on('keydown', EventHandlers.keyDown);


### PR DESCRIPTION
It occurs an error in our in-app html page, for IE8 or lower. We could solve this problem by either change the jQuery library from this.appendChild(elem) to this.parentNode.appendChild( elem ), OR by change the jec to append the html() plaintext but not an jquery object.

Lukasz, it is a great project, we have used this library for a few years. Recently, we encounter an error when it tries to append an option. We have fixed our problem locally, I don't know if you accept this changes. Since jec is used in our in-app page, forgive me that I could show you explicitly, say in jsfiddle.  Sorry for the misleading pull request, probably you could assist me to replicate it in jsFiddle, I am also new to html and js. Thanks. 
